### PR TITLE
added prime number function

### DIFF
--- a/src/notebooks/in_class.py
+++ b/src/notebooks/in_class.py
@@ -1,0 +1,10 @@
+# Databricks notebook source
+from pyspark.sql.functions import *
+
+# COMMAND ----------
+
+for i in range(1,1000):
+    if (i % 2 == 0) or (i % 3 == 0) or (i % 5 == 0):
+        i = "W"
+    else:
+        print(i)


### PR DESCRIPTION
Added a prime number function accounting for the following:
- modulo 2 (i % 2)
- modulo 3 (i % 3)
- modulo 5 (i % 5)

For `i in range(1, 1000)`, if any of these modulos equal 0, then nothing will happen (or rather, i will be replaced by "W"). 

For all other `i` values, `i` will be printed.

This should return all prime numbers from 1 to 1000. However, more modulos may need to be added (e.g. i % 7).